### PR TITLE
docs: document http.systemCertificatesNode for internal CA instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ On a secured instance you are prompted for credentials on the first request. It 
 
 ### Internal or corporate certificates
 
-If Sign in reports the instance is not reachable but it is reachable otherwise (a browser opens it, or `curl https://your-instance/api/v1/configs` returns a response), the instance is likely served over HTTPS with a certificate from an internal CA that VS Code's extension host does not trust by default. Enable this setting and reload the window:
+If Sign in reports the instance is not reachable, but `curl` or a browser can reach it, VS Code's extension host is not trusting your instance's certificate. This is common when the instance uses HTTPS with an internal CA: your machine trusts the certificate, but VS Code does not by default.
+
+Enable this setting and reload the window:
 
 ```json
 "http.systemCertificatesNode": true
 ```
 
-This loads the operating system's certificate store, so the extension trusts the same certificates the rest of your machine does.
+It loads the operating system's certificate store, so the extension uses the certificates your machine already trusts.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,13 @@ On a secured instance you are prompted for credentials on the first request. It 
 
 ### Internal or corporate certificates
 
-If Sign in reports the instance is not reachable, but `curl` or a browser can reach it, VS Code's extension host is not trusting your instance's certificate. This is common when the instance uses HTTPS with an internal CA: your machine trusts the certificate, but VS Code does not by default.
+If Sign in reports the instance is not reachable, first check whether the instance itself is reachable:
+
+```
+curl https://your-instance/api/v1/configs
+```
+
+If that returns a response (for example `401 Unauthorized`) but Sign in still fails, VS Code's extension host is not trusting your instance's certificate. This is common when the instance uses HTTPS with an internal CA: your machine trusts the certificate, but VS Code does not by default.
 
 Enable this setting and reload the window:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ On a secured instance you are prompted for credentials on the first request. It 
 
 ### Internal or corporate certificates
 
-If Sign in reports the instance is not reachable but it opens fine in your browser, the instance is likely served over HTTPS with a certificate from an internal CA that VS Code's extension host does not trust by default. Enable this setting and reload the window:
+If Sign in reports the instance is not reachable but it is reachable otherwise (a browser opens it, or `curl https://your-instance/api/v1/configs` returns a response), the instance is likely served over HTTPS with a certificate from an internal CA that VS Code's extension host does not trust by default. Enable this setting and reload the window:
 
 ```json
 "http.systemCertificatesNode": true

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ On a secured instance you are prompted for credentials on the first request. It 
 
 ### Internal or corporate certificates
 
-If Sign in reports the instance is not reachable, first check whether the instance itself is reachable:
+If Sign in reports the instance is not reachable, first confirm the instance itself is reachable. Open it in a browser, or run:
 
 ```
 curl https://your-instance/api/v1/configs
 ```
 
-If that returns a response (for example `401 Unauthorized`) but Sign in still fails, VS Code's extension host is not trusting your instance's certificate. This is common when the instance uses HTTPS with an internal CA: your machine trusts the certificate, but VS Code does not by default.
+If the browser loads it or curl returns a response (for example `401 Unauthorized`) but Sign in still fails, VS Code's extension host is not trusting your instance's certificate. This is common when the instance uses HTTPS with an internal CA: your machine trusts the certificate, but VS Code does not by default.
 
 Enable this setting and reload the window:
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ Set the URL of your Kestra instance, and a tenant if it is multi-tenant:
 
 On a secured instance you are prompted for credentials on the first request. It supports basic auth (username and password), an Enterprise Edition API token (sent as a Bearer token), and a legacy JWT session token. Use the `Kestra: Sign in` command to set or change credentials, and `Kestra: Sign out` to clear them.
 
+### Internal or corporate certificates
+
+If Sign in reports the instance is not reachable but it opens fine in your browser, the instance is likely served over HTTPS with a certificate from an internal CA that VS Code's extension host does not trust by default. Enable this setting and reload the window:
+
+```json
+"http.systemCertificatesNode": true
+```
+
+This loads the operating system's certificate store, so the extension trusts the same certificates your browser does.
+
 ## Usage
 
 ### Schema and autocompletion

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If Sign in reports the instance is not reachable but it is reachable otherwise (
 "http.systemCertificatesNode": true
 ```
 
-This loads the operating system's certificate store, so the extension trusts the same certificates your browser does.
+This loads the operating system's certificate store, so the extension trusts the same certificates the rest of your machine does.
 
 ## Usage
 


### PR DESCRIPTION
- closes #40 