### PR TITLE
fix: keep the instance when opening a namespace in a new window

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Set the URL of your Kestra instance, and a tenant if it is multi-tenant:
 "kestra.api.tenant": "main"
 ```
 
+Both settings work in User settings or in a folder's `.vscode/settings.json`. Set them per folder when you work with more than one instance.
+
 On a secured instance you are prompted for credentials on the first request. It supports basic auth (username and password), an Enterprise Edition API token (sent as a Bearer token), and a legacy JWT session token. Use the `Kestra: Sign in` command to set or change credentials, and `Kestra: Sign out` to clear them.
 
 ### Internal or corporate certificates
@@ -96,7 +98,7 @@ On a flow file, run `Kestra: Preview flow topology` (or the graph button in the 
 
 ### Namespace files
 
-`Kestra: Open namespace` mounts a namespace as a folder: browse, edit, create, rename, and delete its files, with each save writing back to the instance. Editing is live, there is no local copy. The picker lists namespaces you can access, or you can type one.
+`Kestra: Open namespace` mounts a namespace as a folder: browse, edit, create, rename, and delete its files, with each save writing back to the instance. Editing is live, there is no local copy. The picker lists namespaces you can access, or you can type one. The mounted folder stays on the instance it was opened from, so a URL set per folder keeps working in the new window.
 
 `Kestra: Upload file to namespace` pushes the active file, or the files selected in the Explorer, to a namespace. `Kestra: Sync folder to namespace` walks a local folder and uploads every file, creating directories as needed and overwriting files at the same path. It does not delete files that exist only on the instance. Names matching `kestra.namespaceFiles.exclude` (metadata and secret files like `.env` and `*.pem` by default) are skipped.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Set the URL of your Kestra instance, and a tenant if it is multi-tenant:
 "kestra.api.tenant": "main"
 ```
 
-Both settings work in User settings or in a folder's `.vscode/settings.json`. Set them per folder when you work with more than one instance.
+Both settings work in User settings or in a folder's `.vscode/settings.json`. Use the folder's file when you work with more than one instance, one folder per window. They are window settings, so a per folder value in a multi-root workspace does not apply.
 
 On a secured instance you are prompted for credentials on the first request. It supports basic auth (username and password), an Enterprise Edition API token (sent as a Bearer token), and a legacy JWT session token. Use the `Kestra: Sign in` command to set or change credentials, and `Kestra: Sign out` to clear them.
 

--- a/src/test/instanceUri.test.ts
+++ b/src/test/instanceUri.test.ts
@@ -1,0 +1,29 @@
+import * as assert from "assert";
+import {encodeInstanceAuthority, decodeInstanceAuthority} from "../web/instanceUri";
+
+describe("instance authority", () => {
+    it("round-trips a url and tenant", () => {
+        const instance = {url: "http://localhost:8080", tenant: "prod"};
+        assert.deepStrictEqual(decodeInstanceAuthority(encodeInstanceAuthority(instance)), instance);
+    });
+
+    it("round-trips an empty tenant", () => {
+        const instance = {url: "https://kestra.example.com/api/v1", tenant: ""};
+        assert.deepStrictEqual(decodeInstanceAuthority(encodeInstanceAuthority(instance)), instance);
+    });
+
+    it("encodes to a lowercase hex authority", () => {
+        assert.match(encodeInstanceAuthority({url: "http://localhost:8080", tenant: "main"}), /^[0-9a-f]+$/);
+    });
+
+    it("decodes whatever case the authority comes back in", () => {
+        const instance = {url: "http://localhost:8080", tenant: "main"};
+        assert.deepStrictEqual(decodeInstanceAuthority(encodeInstanceAuthority(instance).toUpperCase()), instance);
+    });
+
+    it("returns undefined for an authority this extension did not write", () => {
+        for (const authority of ["", "github", "zz", "abc", "6162"]) {
+            assert.strictEqual(decodeInstanceAuthority(authority), undefined);
+        }
+    });
+});

--- a/src/test/instanceUri.test.ts
+++ b/src/test/instanceUri.test.ts
@@ -13,7 +13,7 @@ describe("instance authority", () => {
     });
 
     it("encodes to a lowercase hex authority", () => {
-        assert.match(encodeInstanceAuthority({url: "http://localhost:8080", tenant: "main"}), /^[0-9a-f]+$/);
+        assert.match(encodeInstanceAuthority({url: "http://localhost:8080", tenant: "main"}), /^[0-9a-f]+-[0-9a-f]+$/);
     });
 
     it("decodes whatever case the authority comes back in", () => {
@@ -21,9 +21,14 @@ describe("instance authority", () => {
         assert.deepStrictEqual(decodeInstanceAuthority(encodeInstanceAuthority(instance).toUpperCase()), instance);
     });
 
+    it("keeps a url containing the separator intact", () => {
+        const instance = {url: "http://host:8080/api/v1?x=a-b|c", tenant: "main"};
+        assert.deepStrictEqual(decodeInstanceAuthority(encodeInstanceAuthority(instance)), instance);
+    });
+
     it("returns undefined for an authority this extension did not write", () => {
-        for (const authority of ["", "github", "zz", "abc", "6162"]) {
-            assert.strictEqual(decodeInstanceAuthority(authority), undefined);
+        for (const authority of ["", "github", "zz", "abc", "6162", "-", "61-62-63", "ab-cd", "some-host"]) {
+            assert.strictEqual(decodeInstanceAuthority(authority), undefined, `decoded "${authority}"`);
         }
     });
 });

--- a/src/test/instanceUri.test.ts
+++ b/src/test/instanceUri.test.ts
@@ -32,3 +32,9 @@ describe("instance authority", () => {
         }
     });
 });
+
+describe("instance authority with no url", () => {
+    it("encodes to nothing rather than to a corrupt authority", () => {
+        assert.strictEqual(encodeInstanceAuthority({url: "", tenant: "main"}), "");
+    });
+});

--- a/src/web/apiClient.ts
+++ b/src/web/apiClient.ts
@@ -113,12 +113,12 @@ export default class ApiClient {
                 value: kestraConfigUrl || kestraBaseUrl
             });
 
-            if (kestraInputUrl === undefined) {
+            if (!kestraInputUrl?.trim()) {
                 vscode.window.showErrorMessage("A Kestra instance URL is required.");
                 return "";
             }
 
-            finalUrl = this.formatApiUrl(kestraInputUrl);
+            finalUrl = this.formatApiUrl(kestraInputUrl.trim());
 
             // url was updated, we must save it to config. A settings file that cannot be written is
             // worth reporting, but the caller still has the url it asked for, so it is not fatal.
@@ -475,9 +475,17 @@ export default class ApiClient {
         return updated;
     }
 
+    private static originOf(url: string): string {
+        try {
+            return new URL(url).origin;
+        } catch {
+            return url;
+        }
+    }
+
     private async handleFetchError(response: Response, url: string, errorMessage: string, ignoreCodes: number[] = [], options?: RequestInit) {
         if (response.status === 401) {
-            vscode.window.showInformationMessage("This Kestra instance requires authentication.");
+            vscode.window.showInformationMessage(`${ApiClient.originOf(url)} requires authentication.`);
             try {
                 let newResponse = await this.askCredentialsAndFetch(url, options);
 
@@ -517,7 +525,7 @@ export default class ApiClient {
 
             if (!storedUsername || !storedPassword) {
                 username = await vscode.window.showInputBox({
-                    prompt: "Username (press Escape to use a token instead)",
+                    prompt: `Username for ${ApiClient.originOf(url)} (press Escape to use a token instead)`,
                     value: storedUsername || ""
                 });
 
@@ -567,7 +575,7 @@ export default class ApiClient {
         const isApiToken = choice === apiToken;
 
         const token = await vscode.window.showInputBox({
-            prompt: isApiToken ? "Kestra API token" : "JWT token (copy it from the Kestra UI)",
+            prompt: `${isApiToken ? "Kestra API token" : "JWT token (copy it from the Kestra UI)"} for ${ApiClient.originOf(url)}`,
             password: true,
             placeHolder: "Paste your token here"
         });

--- a/src/web/apiClient.ts
+++ b/src/web/apiClient.ts
@@ -9,8 +9,7 @@ import type { KestraInstance } from "./instanceUri";
 export default class ApiClient {
     private readonly _secretStorage: vscode.SecretStorage;
 
-    // A namespace folder is virtual and has no settings of its own, so the window is pinned to the
-    // instance it was opened from. The pin wins over settings for the whole window.
+    // A namespace folder has no settings of its own, so its window pins the instance instead.
     private static pinnedInstance: KestraInstance | undefined;
 
     public constructor(secretStorage: vscode.SecretStorage) {
@@ -21,7 +20,7 @@ export default class ApiClient {
         ApiClient.pinnedInstance = instance;
     }
 
-    // The instance this window talks to, with the url exactly as configured (not normalized).
+    // Url as configured, not normalized: secret keys are built from it.
     public static currentInstance(): KestraInstance {
         if (ApiClient.pinnedInstance) {
             return ApiClient.pinnedInstance;
@@ -106,7 +105,7 @@ export default class ApiClient {
         const kestraConfigUrl = ApiClient.currentInstance().url;
         let finalUrl = this.formatApiUrl(kestraConfigUrl);
 
-        // A pinned window is bound to one instance, so asking for a url there would be a no-op.
+        // A pinned window is bound to one instance, so a prompt there would be a no-op.
         if (vscode.env.uiKind !== vscode.UIKind.Web && !ApiClient.pinnedInstance && (!kestraConfigUrl || forceInput)) {
             const kestraInputUrl = await vscode.window.showInputBox({
                 prompt: "Kestra instance URL",
@@ -120,8 +119,7 @@ export default class ApiClient {
 
             finalUrl = this.formatApiUrl(kestraInputUrl.trim());
 
-            // url was updated, we must save it to config. A settings file that cannot be written is
-            // worth reporting, but the caller still has the url it asked for, so it is not fatal.
+            // url was updated, we must save it to config
             if (kestraConfigUrl !== finalUrl) {
                 try {
                     await vscode.workspace.getConfiguration('kestra.api').update('url', finalUrl, this.urlTarget());
@@ -134,8 +132,7 @@ export default class ApiClient {
         return includeTenant ? this.withTenant(finalUrl) : finalUrl;
     }
 
-    // The answer goes back to the scope the url already lives in, so replying to the prompt in a
-    // folder that configures its own instance does not change every other workspace.
+    // Write back to the scope the url already lives in, not always User settings.
     private static urlTarget(): vscode.ConfigurationTarget {
         const scopes = vscode.workspace.getConfiguration("kestra.api").inspect<string>("url");
         return scopes?.workspaceValue !== undefined

--- a/src/web/apiClient.ts
+++ b/src/web/apiClient.ts
@@ -23,10 +23,15 @@ export default class ApiClient {
 
     // The instance this window talks to, with the url exactly as configured (not normalized).
     public static currentInstance(): KestraInstance {
-        return ApiClient.pinnedInstance ?? {
-            url: (vscode.workspace.getConfiguration("kestra.api").get("url") as string) || "",
-            tenant: (vscode.workspace.getConfiguration("kestra.api").get("tenant") as string) || ""
-        };
+        if (ApiClient.pinnedInstance) {
+            return ApiClient.pinnedInstance;
+        }
+        const config = vscode.workspace.getConfiguration("kestra.api");
+        return {url: (config.get("url") as string) || "", tenant: (config.get("tenant") as string) || ""};
+    }
+
+    public static isPinned(): boolean {
+        return ApiClient.pinnedInstance !== undefined;
     }
 
     public async signIn(): Promise<void> {
@@ -115,9 +120,14 @@ export default class ApiClient {
 
             finalUrl = this.formatApiUrl(kestraInputUrl);
 
-            // url was updated, we must save it to config
+            // url was updated, we must save it to config. A settings file that cannot be written is
+            // worth reporting, but the caller still has the url it asked for, so it is not fatal.
             if (kestraConfigUrl !== finalUrl) {
-                await vscode.workspace.getConfiguration('kestra.api').update('url', finalUrl, this.urlTarget());
+                try {
+                    await vscode.workspace.getConfiguration('kestra.api').update('url', finalUrl, this.urlTarget());
+                } catch (error) {
+                    logWarn(`Could not save kestra.api.url: ${error instanceof Error ? error.message : String(error)}`);
+                }
             }
         }
 
@@ -128,7 +138,7 @@ export default class ApiClient {
     // folder that configures its own instance does not change every other workspace.
     private static urlTarget(): vscode.ConfigurationTarget {
         const scopes = vscode.workspace.getConfiguration("kestra.api").inspect<string>("url");
-        return scopes?.workspaceValue !== undefined || scopes?.workspaceFolderValue !== undefined
+        return scopes?.workspaceValue !== undefined
             ? vscode.ConfigurationTarget.Workspace
             : vscode.ConfigurationTarget.Global;
     }

--- a/src/web/apiClient.ts
+++ b/src/web/apiClient.ts
@@ -4,12 +4,29 @@ import { kestraBaseUrl, secretStorageKey, yamlContentType, PebbleFunctionDef } f
 import { FlowGraph } from "../shared/flow";
 import type { PluginDefinition, PluginEntry } from "./documentation/pluginDoc";
 import { logWarn } from "./log";
+import type { KestraInstance } from "./instanceUri";
 
 export default class ApiClient {
     private readonly _secretStorage: vscode.SecretStorage;
 
+    // A namespace folder is virtual and has no settings of its own, so the window is pinned to the
+    // instance it was opened from. The pin wins over settings for the whole window.
+    private static pinnedInstance: KestraInstance | undefined;
+
     public constructor(secretStorage: vscode.SecretStorage) {
         this._secretStorage = secretStorage;
+    }
+
+    public static pinInstance(instance: KestraInstance): void {
+        ApiClient.pinnedInstance = instance;
+    }
+
+    // The instance this window talks to, with the url exactly as configured (not normalized).
+    public static currentInstance(): KestraInstance {
+        return ApiClient.pinnedInstance ?? {
+            url: (vscode.workspace.getConfiguration("kestra.api").get("url") as string) || "",
+            tenant: (vscode.workspace.getConfiguration("kestra.api").get("tenant") as string) || ""
+        };
     }
 
     public async signIn(): Promise<void> {
@@ -54,7 +71,7 @@ export default class ApiClient {
     // GET /configs is the lightweight authenticated endpoint the Kestra UI itself uses to validate a login.
     // Fetches directly (not via silentFetch) so the thrown cause is surfaced instead of a blanket "unreachable".
     public async verifyCredentials(): Promise<{status: "ok" | "unauthorized" | "unreachable", detail?: string}> {
-        if (!(vscode.workspace.getConfiguration("kestra.api").get("url") as string)) {
+        if (!ApiClient.currentInstance().url) {
             return {status: "unreachable", detail: "no kestra.api.url configured"};
         }
         try {
@@ -81,13 +98,14 @@ export default class ApiClient {
     }
 
     public static async getKestraApiUrl(forceInput: boolean = false, includeTenant: boolean = true): Promise<string> {
-        const kestraConfigUrl = (vscode.workspace.getConfiguration("kestra.api").get("url") as string);
+        const kestraConfigUrl = ApiClient.currentInstance().url;
         let finalUrl = this.formatApiUrl(kestraConfigUrl);
 
-        if (vscode.env.uiKind !== vscode.UIKind.Web && (!kestraConfigUrl || forceInput)) {
+        // A pinned window is bound to one instance, so asking for a url there would be a no-op.
+        if (vscode.env.uiKind !== vscode.UIKind.Web && !ApiClient.pinnedInstance && (!kestraConfigUrl || forceInput)) {
             const kestraInputUrl = await vscode.window.showInputBox({
                 prompt: "Kestra instance URL",
-                value: kestraConfigUrl ?? kestraBaseUrl
+                value: kestraConfigUrl || kestraBaseUrl
             });
 
             if (kestraInputUrl === undefined) {
@@ -99,15 +117,24 @@ export default class ApiClient {
 
             // url was updated, we must save it to config
             if (kestraConfigUrl !== finalUrl) {
-                vscode.workspace.getConfiguration('kestra.api').update('url', finalUrl, vscode.ConfigurationTarget.Global);
+                await vscode.workspace.getConfiguration('kestra.api').update('url', finalUrl, this.urlTarget());
             }
         }
 
         return includeTenant ? this.withTenant(finalUrl) : finalUrl;
     }
 
+    // The answer goes back to the scope the url already lives in, so replying to the prompt in a
+    // folder that configures its own instance does not change every other workspace.
+    private static urlTarget(): vscode.ConfigurationTarget {
+        const scopes = vscode.workspace.getConfiguration("kestra.api").inspect<string>("url");
+        return scopes?.workspaceValue !== undefined || scopes?.workspaceFolderValue !== undefined
+            ? vscode.ConfigurationTarget.Workspace
+            : vscode.ConfigurationTarget.Global;
+    }
+
     private static withTenant(url: string): string {
-        const tenant = (vscode.workspace.getConfiguration("kestra.api").get("tenant") as string);
+        const tenant = ApiClient.currentInstance().tenant;
         if (!url || !tenant) {
             return url;
         }
@@ -116,7 +143,7 @@ export default class ApiClient {
 
     public static async executionUiUrl(namespace: string, flowId: string, executionId: string): Promise<string> {
         const webUrl = (await this.getKestraApiUrl()).split("/api/v1")[0];
-        const tenant = (vscode.workspace.getConfiguration("kestra.api").get("tenant") as string) || "main";
+        const tenant = ApiClient.currentInstance().tenant || "main";
         return `${webUrl}/ui/${tenant}/executions/${namespace}/${flowId}/${executionId}`;
     }
 
@@ -136,7 +163,7 @@ export default class ApiClient {
 
     // SecretStorage is global to the extension, so scope credentials to the instance URL.
     private secretKey(base: string): string {
-        const url = (vscode.workspace.getConfiguration("kestra.api").get("url") as string) || "";
+        const url = ApiClient.currentInstance().url;
         return url ? `${base}::${url}` : base;
     }
 
@@ -391,7 +418,7 @@ export default class ApiClient {
     }
 
     private async silentFetch(suffix: string, options: RequestInit = {}, includeTenant: boolean = true): Promise<Response | null> {
-        if (!(vscode.workspace.getConfiguration("kestra.api").get("url") as string)) {
+        if (!ApiClient.currentInstance().url) {
             return null;
         }
         try {

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -12,6 +12,9 @@ export interface PebbleFunctionDef {
     arguments: Array<{name: string; defaultValue: string | null}>;
 }
 
+// Instances the user has opened a namespace on, which a folder URI may pin to without asking.
+export const knownInstancesKey = "kestra.instances.known";
+
 export const schemaStateKey = {
     schema: "kestra.yaml.schema",
     source: "kestra.yaml.schema.source"

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -1,5 +1,8 @@
 export const kestraBaseUrl = "https://api.kestra.io/v1";
 
+// URI scheme of a mounted namespace folder.
+export const kestraScheme = "kestra";
+
 export const yamlContentType = "application/x-yaml";
 
 export const flowSchemaUri = "kestra:/flow-schema.json";

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -1,6 +1,5 @@
 export const kestraBaseUrl = "https://api.kestra.io/v1";
 
-// URI scheme of a mounted namespace folder.
 export const kestraScheme = "kestra";
 
 export const yamlContentType = "application/x-yaml";
@@ -12,7 +11,7 @@ export interface PebbleFunctionDef {
     arguments: Array<{name: string; defaultValue: string | null}>;
 }
 
-// Instances the user has opened a namespace on, which a folder URI may pin to without asking.
+// Instances a folder URI may pin to without asking.
 export const knownInstancesKey = "kestra.instances.known";
 
 export const schemaStateKey = {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -11,6 +11,7 @@ import {runFlowFromEditor, saveFlowFromEditor} from './flowRunner';
 import {disposeRunLogs} from './runOutput';
 import {resolveConfiguredNamespace, uploadFileToNamespace, syncFolderToNamespace} from './namespaceFiles';
 import {initLog} from './log';
+import {decodeInstanceAuthority, encodeInstanceAuthority} from './instanceUri';
 
 async function downloadSchema(globalState: vscode.Memento, apiClient: ApiClient, opts: {silent: boolean, forceInput?: boolean}): Promise<boolean> {
     // The plugin schema endpoint is global, not tenant-scoped.
@@ -69,7 +70,15 @@ function openNamespaceCommand(apiClient: ApiClient) {
         if (!namespace) {
             return;
         }
-        await vscode.commands.executeCommand('vscode.openFolder', vscode.Uri.parse(`kestra:///${namespace}`), {forceNewWindow: true});
+        // The new window is a virtual folder with no settings of its own, so the instance travels
+        // on the folder URI. Without it the window falls back to User settings and can miss, or
+        // pick the wrong, kestra.api.url.
+        const folder = vscode.Uri.from({
+            scheme: 'kestra',
+            authority: encodeInstanceAuthority(ApiClient.currentInstance()),
+            path: `/${namespace}`
+        });
+        await vscode.commands.executeCommand('vscode.openFolder', folder, {forceNewWindow: true});
     });
 }
 
@@ -90,8 +99,13 @@ export async function activate(context: vscode.ExtensionContext) {
     const openedWs = vscode.workspace.workspaceFolders?.[0];
     const apiClient = new ApiClient(context.secrets);
     if (openedWs?.uri?.scheme === "kestra") {
-        const namespace = openedWs.name;
-        const kestraFs = new KestraFS(namespace, apiClient);
+        const root = openedWs.uri;
+        const instance = decodeInstanceAuthority(root.authority);
+        if (instance) {
+            ApiClient.pinInstance(instance);
+        }
+        const namespace = root.path.replace(/^\/+/, "") || openedWs.name;
+        const kestraFs = new KestraFS(namespace, apiClient, root.authority);
 
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider('kestra', kestraFs));
         context.subscriptions.push(vscode.workspace.registerFileSearchProvider('kestra', new KestraFileSearchProvider(namespace, kestraFs, apiClient)));
@@ -115,7 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
     registerPebbleCompletion(context, apiClient);
     registerRequiredFieldsCompletion(context);
 
-    const configuredUrl = vscode.workspace.getConfiguration("kestra.api").get("url") as string;
+    const configuredUrl = ApiClient.currentInstance().url;
     if (vscode.env.uiKind === vscode.UIKind.Web) {
         await downloadSchema(context.globalState, apiClient, {silent: true});
     } else if (configuredUrl) {

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -10,7 +10,7 @@ import {registerRequiredFieldsCompletion} from './requiredFieldsCompletion';
 import {runFlowFromEditor, saveFlowFromEditor} from './flowRunner';
 import {disposeRunLogs} from './runOutput';
 import {resolveConfiguredNamespace, uploadFileToNamespace, syncFolderToNamespace} from './namespaceFiles';
-import {initLog} from './log';
+import {initLog, logInfo, logWarn} from './log';
 import {decodeInstanceAuthority, encodeInstanceAuthority} from './instanceUri';
 
 async function downloadSchema(globalState: vscode.Memento, apiClient: ApiClient, opts: {silent: boolean, forceInput?: boolean}): Promise<boolean> {
@@ -103,8 +103,15 @@ export async function activate(context: vscode.ExtensionContext) {
         const instance = decodeInstanceAuthority(root.authority);
         if (instance) {
             ApiClient.pinInstance(instance);
+            // Output channels end up pasted into bug reports, so drop any user:password@ in the url.
+            const shown = instance.url.replace(/\/\/[^/@]*@/, "//");
+            logInfo(`Namespace window pinned to ${shown}${instance.tenant ? ` (tenant ${instance.tenant})` : ""}`);
+        } else if (root.authority) {
+            // Silence is right for a legacy kestra:///namespace folder, but an authority we cannot
+            // read means the window is about to fall back to settings and may hit another instance.
+            logWarn(`Ignored an unreadable instance on the folder URI, falling back to kestra.api.url. Reopen the namespace with "Kestra: Open namespace" if it targets the wrong instance.`);
         }
-        const namespace = root.path.replace(/^\/+/, "") || openedWs.name;
+        const namespace = root.path.replace(/^\/+/, "").replace(/\/+$/, "") || openedWs.name;
         const kestraFs = new KestraFS(namespace, apiClient, root.authority);
 
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider('kestra', kestraFs));
@@ -141,6 +148,9 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async (event) => {
+        if (ApiClient.isPinned()) {
+            return;
+        }
         if (event.affectsConfiguration("kestra.api.url") || event.affectsConfiguration("kestra.api.tenant")) {
             resetPebbleCache();
             await downloadSchema(context.globalState, apiClient, {silent: true});

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import {KestraFileSearchProvider, KestraFS} from './kestraFsProvider';
 import DocumentationPanel from "./documentation/documentation";
 import ApiClient from './apiClient';
-import {schemaStateKey, flowSchemaUri} from './constants';
+import {schemaStateKey, flowSchemaUri, kestraScheme} from './constants';
 import {registerFlowValidation, isFlowDocument} from './flowValidation';
 import {registerPebbleCompletion, resetPebbleCache} from './pebbleCompletion';
 import TopologyPanel, {registerTopologyRefresh} from './topologyPanel';
@@ -12,6 +12,9 @@ import {disposeRunLogs} from './runOutput';
 import {resolveConfiguredNamespace, uploadFileToNamespace, syncFolderToNamespace} from './namespaceFiles';
 import {initLog, logInfo, logWarn} from './log';
 import {decodeInstanceAuthority, encodeInstanceAuthority} from './instanceUri';
+
+// user:password@ in a url, which must never reach the output channel.
+const urlUserinfo = /\/\/[^/@]*@/;
 
 async function downloadSchema(globalState: vscode.Memento, apiClient: ApiClient, opts: {silent: boolean, forceInput?: boolean}): Promise<boolean> {
     // The plugin schema endpoint is global, not tenant-scoped.
@@ -74,7 +77,7 @@ function openNamespaceCommand(apiClient: ApiClient) {
         // on the folder URI. Without it the window falls back to User settings and can miss, or
         // pick the wrong, kestra.api.url.
         const folder = vscode.Uri.from({
-            scheme: 'kestra',
+            scheme: kestraScheme,
             authority: encodeInstanceAuthority(ApiClient.currentInstance()),
             path: `/${namespace}`
         });
@@ -98,24 +101,24 @@ export async function activate(context: vscode.ExtensionContext) {
     initLog(context);
     const openedWs = vscode.workspace.workspaceFolders?.[0];
     const apiClient = new ApiClient(context.secrets);
-    if (openedWs?.uri?.scheme === "kestra") {
+    if (openedWs?.uri?.scheme === kestraScheme) {
         const root = openedWs.uri;
         const instance = decodeInstanceAuthority(root.authority);
         if (instance) {
             ApiClient.pinInstance(instance);
-            // Output channels end up pasted into bug reports, so drop any user:password@ in the url.
-            const shown = instance.url.replace(/\/\/[^/@]*@/, "//");
+            // Output channels end up pasted into bug reports.
+            const shown = instance.url.replace(urlUserinfo, "//");
             logInfo(`Namespace window pinned to ${shown}${instance.tenant ? ` (tenant ${instance.tenant})` : ""}`);
         } else if (root.authority) {
             // Silence is right for a legacy kestra:///namespace folder, but an authority we cannot
             // read means the window is about to fall back to settings and may hit another instance.
             logWarn(`Ignored an unreadable instance on the folder URI, falling back to kestra.api.url. Reopen the namespace with "Kestra: Open namespace" if it targets the wrong instance.`);
         }
-        const namespace = root.path.replace(/^\/+/, "").replace(/\/+$/, "") || openedWs.name;
+        const namespace = root.path.split("/").filter(Boolean).join("/") || openedWs.name;
         const kestraFs = new KestraFS(namespace, apiClient, root.authority);
 
-        context.subscriptions.push(vscode.workspace.registerFileSystemProvider('kestra', kestraFs));
-        context.subscriptions.push(vscode.workspace.registerFileSearchProvider('kestra', new KestraFileSearchProvider(namespace, kestraFs, apiClient)));
+        context.subscriptions.push(vscode.workspace.registerFileSystemProvider(kestraScheme, kestraFs));
+        context.subscriptions.push(vscode.workspace.registerFileSearchProvider(kestraScheme, new KestraFileSearchProvider(namespace, kestraFs, apiClient)));
 
         await kestraFs.start().catch(() => undefined);
     }

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import {KestraFileSearchProvider, KestraFS} from './kestraFsProvider';
 import DocumentationPanel from "./documentation/documentation";
 import ApiClient from './apiClient';
-import {schemaStateKey, flowSchemaUri, kestraScheme} from './constants';
+import {schemaStateKey, flowSchemaUri, kestraScheme, knownInstancesKey} from './constants';
 import {registerFlowValidation, isFlowDocument} from './flowValidation';
 import {registerPebbleCompletion, resetPebbleCache} from './pebbleCompletion';
 import TopologyPanel, {registerTopologyRefresh} from './topologyPanel';
@@ -10,11 +10,41 @@ import {registerRequiredFieldsCompletion} from './requiredFieldsCompletion';
 import {runFlowFromEditor, saveFlowFromEditor} from './flowRunner';
 import {disposeRunLogs} from './runOutput';
 import {resolveConfiguredNamespace, uploadFileToNamespace, syncFolderToNamespace} from './namespaceFiles';
-import {initLog, logInfo, logWarn} from './log';
+import {initLog, logInfo} from './log';
 import {decodeInstanceAuthority, encodeInstanceAuthority} from './instanceUri';
 
 // user:password@ in a url, which must never reach the output channel.
 const urlUserinfo = /\/\/[^/@]*@/;
+
+function hostOf(url: string): string {
+    try {
+        return new URL(url).host;
+    } catch {
+        return url.replace(urlUserinfo, "//");
+    }
+}
+
+async function rememberInstance(globalState: vscode.Memento, url: string): Promise<void> {
+    const known = globalState.get<string[]>(knownInstancesKey) ?? [];
+    if (!known.includes(url)) {
+        await globalState.update(knownInstancesKey, [...known, url]);
+    }
+}
+
+// A folder URI can come from anywhere, a shared .code-workspace included, and it now decides which
+// host the window talks to and offers credentials to. Pin without asking only for an instance the
+// user has opened a namespace on before.
+async function confirmInstance(globalState: vscode.Memento, url: string): Promise<boolean> {
+    if ((globalState.get<string[]>(knownInstancesKey) ?? []).includes(url)) {
+        return true;
+    }
+    const connect = await vscode.window.showWarningMessage(
+        `This folder points at ${hostOf(url)}, which you have not opened a namespace on before.`,
+        {modal: true, detail: "Connect only if you trust this Kestra instance. It receives the files you open and any credentials you enter."},
+        "Connect"
+    );
+    return connect === "Connect";
+}
 
 async function downloadSchema(globalState: vscode.Memento, apiClient: ApiClient, opts: {silent: boolean, forceInput?: boolean}): Promise<boolean> {
     // The plugin schema endpoint is global, not tenant-scoped.
@@ -67,18 +97,21 @@ function signInCommand(apiClient: ApiClient) {
     return vscode.commands.registerCommand('kestra.auth.signIn', () => apiClient.signIn());
 }
 
-function openNamespaceCommand(apiClient: ApiClient) {
+function openNamespaceCommand(globalState: vscode.Memento, apiClient: ApiClient) {
     return vscode.commands.registerCommand('kestra.namespace.open', async () => {
         const namespace = await resolveConfiguredNamespace(apiClient, true);
         if (!namespace) {
             return;
         }
+        const instance = ApiClient.currentInstance();
+        // Opening from settings is the act that makes an instance known to the new window.
+        await rememberInstance(globalState, instance.url);
         // The new window is a virtual folder with no settings of its own, so the instance travels
         // on the folder URI. Without it the window falls back to User settings and can miss, or
         // pick the wrong, kestra.api.url.
         const folder = vscode.Uri.from({
             scheme: kestraScheme,
-            authority: encodeInstanceAuthority(ApiClient.currentInstance()),
+            authority: encodeInstanceAuthority(instance),
             path: `/${namespace}`
         });
         await vscode.commands.executeCommand('vscode.openFolder', folder, {forceNewWindow: true});
@@ -104,21 +137,21 @@ export async function activate(context: vscode.ExtensionContext) {
     if (openedWs?.uri?.scheme === kestraScheme) {
         const root = openedWs.uri;
         const instance = decodeInstanceAuthority(root.authority);
-        if (instance) {
+        if (instance && await confirmInstance(context.globalState, instance.url)) {
             ApiClient.pinInstance(instance);
             // Output channels end up pasted into bug reports.
-            const shown = instance.url.replace(urlUserinfo, "//");
-            logInfo(`Namespace window pinned to ${shown}${instance.tenant ? ` (tenant ${instance.tenant})` : ""}`);
+            logInfo(`Namespace window pinned to ${instance.url.replace(urlUserinfo, "//")}${instance.tenant ? ` (tenant ${instance.tenant})` : ""}`);
         } else if (root.authority) {
-            // Silence is right for a legacy kestra:///namespace folder, but an authority we cannot
-            // read means the window is about to fall back to settings and may hit another instance.
-            logWarn(`Ignored an unreadable instance on the folder URI, falling back to kestra.api.url. Reopen the namespace with "Kestra: Open namespace" if it targets the wrong instance.`);
+            // Falling back to settings means the files below may belong to a different instance,
+            // which is worth interrupting for. A legacy kestra:///namespace folder has no authority
+            // and never reaches this.
+            vscode.window.showWarningMessage(`This namespace is not connected to the instance it was opened from, so it uses kestra.api.url instead. Reopen it with "Kestra: Open namespace" to be sure of the instance.`);
         }
         const namespace = root.path.split("/").filter(Boolean).join("/") || openedWs.name;
         const kestraFs = new KestraFS(namespace, apiClient, root.authority);
 
         context.subscriptions.push(vscode.workspace.registerFileSystemProvider(kestraScheme, kestraFs));
-        context.subscriptions.push(vscode.workspace.registerFileSearchProvider(kestraScheme, new KestraFileSearchProvider(namespace, kestraFs, apiClient)));
+        context.subscriptions.push(vscode.workspace.registerFileSearchProvider(kestraScheme, new KestraFileSearchProvider(kestraFs)));
 
         await kestraFs.start().catch(() => undefined);
     }
@@ -126,7 +159,7 @@ export async function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(showDocumentation(context, apiClient));
     context.subscriptions.push(signInCommand(apiClient));
     context.subscriptions.push(signOutCommand(apiClient));
-    context.subscriptions.push(openNamespaceCommand(apiClient));
+    context.subscriptions.push(openNamespaceCommand(context.globalState, apiClient));
     context.subscriptions.push(uploadFileCommand(apiClient));
     context.subscriptions.push(syncFolderCommand(apiClient));
     context.subscriptions.push(runFlowCommand(apiClient, context.extensionUri));

--- a/src/web/extension.ts
+++ b/src/web/extension.ts
@@ -13,7 +13,7 @@ import {resolveConfiguredNamespace, uploadFileToNamespace, syncFolderToNamespace
 import {initLog, logInfo} from './log';
 import {decodeInstanceAuthority, encodeInstanceAuthority} from './instanceUri';
 
-// user:password@ in a url, which must never reach the output channel.
+// user:password@ in a url.
 const urlUserinfo = /\/\/[^/@]*@/;
 
 function hostOf(url: string): string {
@@ -31,9 +31,7 @@ async function rememberInstance(globalState: vscode.Memento, url: string): Promi
     }
 }
 
-// A folder URI can come from anywhere, a shared .code-workspace included, and it now decides which
-// host the window talks to and offers credentials to. Pin without asking only for an instance the
-// user has opened a namespace on before.
+// A folder URI can come from anywhere, and decides which host gets our requests and credentials.
 async function confirmInstance(globalState: vscode.Memento, url: string): Promise<boolean> {
     if ((globalState.get<string[]>(knownInstancesKey) ?? []).includes(url)) {
         return true;
@@ -104,11 +102,8 @@ function openNamespaceCommand(globalState: vscode.Memento, apiClient: ApiClient)
             return;
         }
         const instance = ApiClient.currentInstance();
-        // Opening from settings is the act that makes an instance known to the new window.
+        // Opening from settings is what makes an instance known.
         await rememberInstance(globalState, instance.url);
-        // The new window is a virtual folder with no settings of its own, so the instance travels
-        // on the folder URI. Without it the window falls back to User settings and can miss, or
-        // pick the wrong, kestra.api.url.
         const folder = vscode.Uri.from({
             scheme: kestraScheme,
             authority: encodeInstanceAuthority(instance),
@@ -142,9 +137,7 @@ export async function activate(context: vscode.ExtensionContext) {
             // Output channels end up pasted into bug reports.
             logInfo(`Namespace window pinned to ${instance.url.replace(urlUserinfo, "//")}${instance.tenant ? ` (tenant ${instance.tenant})` : ""}`);
         } else if (root.authority) {
-            // Falling back to settings means the files below may belong to a different instance,
-            // which is worth interrupting for. A legacy kestra:///namespace folder has no authority
-            // and never reaches this.
+            // A legacy kestra:///namespace folder has no authority and never reaches this.
             vscode.window.showWarningMessage(`This namespace is not connected to the instance it was opened from, so it uses kestra.api.url instead. Reopen it with "Kestra: Open namespace" to be sure of the instance.`);
         }
         const namespace = root.path.split("/").filter(Boolean).join("/") || openedWs.name;

--- a/src/web/instanceUri.ts
+++ b/src/web/instanceUri.ts
@@ -4,13 +4,17 @@
 
 export type KestraInstance = {url: string; tenant: string};
 
+// Splits the two hex runs, so it must be a character hex never produces and a URI authority allows.
+const fieldSeparator = "-";
+const hexPattern = /^[0-9a-f]*$/i;
+
 // URI authorities are not guaranteed to keep their case, so the payload is hex, which survives it.
 function toHex(text: string): string {
     return Array.from(new TextEncoder().encode(text), byte => byte.toString(16).padStart(2, "0")).join("");
 }
 
 function fromHex(hex: string): string | undefined {
-    if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
+    if (hex.length % 2 !== 0 || !hexPattern.test(hex)) {
         return undefined;
     }
     const bytes = new Uint8Array(hex.length / 2);
@@ -29,13 +33,13 @@ function fromHex(hex: string): string | undefined {
 // The url and the tenant are separate hex runs, so neither has to avoid a separator character. The
 // url is kept exactly as configured, not normalized, so credentials scoped per url still match.
 export function encodeInstanceAuthority(instance: KestraInstance): string {
-    return `${toHex(instance.url)}-${toHex(instance.tenant)}`;
+    return `${toHex(instance.url)}${fieldSeparator}${toHex(instance.tenant)}`;
 }
 
 // Undefined for anything this extension did not write, so older kestra:///namespace folders and the
 // ones the Kestra UI opens in the browser keep reading the instance from settings.
 export function decodeInstanceAuthority(authority: string): KestraInstance | undefined {
-    const parts = authority.split("-");
+    const parts = authority.split(fieldSeparator);
     if (parts.length !== 2) {
         return undefined;
     }

--- a/src/web/instanceUri.ts
+++ b/src/web/instanceUri.ts
@@ -33,7 +33,8 @@ function fromHex(hex: string): string | undefined {
 // The url and the tenant are separate hex runs, so neither has to avoid a separator character. The
 // url is kept exactly as configured, not normalized, so credentials scoped per url still match.
 export function encodeInstanceAuthority(instance: KestraInstance): string {
-    return `${toHex(instance.url)}${fieldSeparator}${toHex(instance.tenant)}`;
+    // An empty url pins nothing, and would encode to an authority that decodes back as corrupt.
+    return instance.url ? `${toHex(instance.url)}${fieldSeparator}${toHex(instance.tenant)}` : "";
 }
 
 // Undefined for anything this extension did not write, so older kestra:///namespace folders and the

--- a/src/web/instanceUri.ts
+++ b/src/web/instanceUri.ts
@@ -1,0 +1,41 @@
+// A kestra:// folder is virtual, so it carries no .vscode/settings.json. Without the instance
+// encoded on the folder URI, a namespace window falls back to User settings and loses a
+// kestra.api.url that was set per workspace.
+
+export type KestraInstance = {url: string; tenant: string};
+
+// URI authorities are not guaranteed to keep their case, so the payload is hex, which survives it.
+function toHex(text: string): string {
+    return Array.from(new TextEncoder().encode(text), byte => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function fromHex(hex: string): string | undefined {
+    if (hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(hex)) {
+        return undefined;
+    }
+    const bytes = new Uint8Array(hex.length / 2);
+    for (let i = 0; i < bytes.length; i++) {
+        bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    }
+    return new TextDecoder().decode(bytes);
+}
+
+// The url is kept exactly as configured, not normalized, so credentials scoped per url still match.
+export function encodeInstanceAuthority(instance: KestraInstance): string {
+    return toHex(`${instance.url}|${instance.tenant}`);
+}
+
+// Undefined for anything this extension did not write, so older kestra:///namespace folders and the
+// ones the Kestra UI opens in the browser keep reading the instance from settings.
+export function decodeInstanceAuthority(authority: string): KestraInstance | undefined {
+    const decoded = authority ? fromHex(authority) : undefined;
+    if (decoded === undefined) {
+        return undefined;
+    }
+    const separator = decoded.indexOf("|");
+    if (separator === -1) {
+        return undefined;
+    }
+    const url = decoded.slice(0, separator);
+    return url ? {url, tenant: decoded.slice(separator + 1)} : undefined;
+}

--- a/src/web/instanceUri.ts
+++ b/src/web/instanceUri.ts
@@ -1,14 +1,12 @@
-// A kestra:// folder is virtual, so it carries no .vscode/settings.json. Without the instance
-// encoded on the folder URI, a namespace window falls back to User settings and loses a
-// kestra.api.url that was set per workspace.
+// A kestra:// folder carries no settings of its own, so the instance rides on the folder URI.
 
 export type KestraInstance = {url: string; tenant: string};
 
-// Splits the two hex runs, so it must be a character hex never produces and a URI authority allows.
+// Must be a character hex never produces and a URI authority allows.
 const fieldSeparator = "-";
 const hexPattern = /^[0-9a-f]*$/i;
 
-// URI authorities are not guaranteed to keep their case, so the payload is hex, which survives it.
+// Hex because URI authorities are not guaranteed to keep their case.
 function toHex(text: string): string {
     return Array.from(new TextEncoder().encode(text), byte => byte.toString(16).padStart(2, "0")).join("");
 }
@@ -22,23 +20,20 @@ function fromHex(hex: string): string | undefined {
         bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
     }
     try {
-        // Decoding strictly rejects hex that is not something this extension wrote, rather than
-        // turning it into replacement characters and pinning the window to a garbage instance.
+        // Strict, so foreign hex is rejected instead of decoding to replacement characters.
         return new TextDecoder("utf-8", {fatal: true}).decode(bytes);
     } catch {
         return undefined;
     }
 }
 
-// The url and the tenant are separate hex runs, so neither has to avoid a separator character. The
-// url is kept exactly as configured, not normalized, so credentials scoped per url still match.
+// Separate hex runs, so neither field has to avoid the separator.
 export function encodeInstanceAuthority(instance: KestraInstance): string {
-    // An empty url pins nothing, and would encode to an authority that decodes back as corrupt.
+    // An empty url would encode to an authority that decodes back as corrupt.
     return instance.url ? `${toHex(instance.url)}${fieldSeparator}${toHex(instance.tenant)}` : "";
 }
 
-// Undefined for anything this extension did not write, so older kestra:///namespace folders and the
-// ones the Kestra UI opens in the browser keep reading the instance from settings.
+// Undefined for anything this extension did not write, so legacy folders fall back to settings.
 export function decodeInstanceAuthority(authority: string): KestraInstance | undefined {
     const parts = authority.split(fieldSeparator);
     if (parts.length !== 2) {

--- a/src/web/instanceUri.ts
+++ b/src/web/instanceUri.ts
@@ -10,32 +10,36 @@ function toHex(text: string): string {
 }
 
 function fromHex(hex: string): string | undefined {
-    if (hex.length === 0 || hex.length % 2 !== 0 || !/^[0-9a-f]+$/i.test(hex)) {
+    if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) {
         return undefined;
     }
     const bytes = new Uint8Array(hex.length / 2);
     for (let i = 0; i < bytes.length; i++) {
         bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
     }
-    return new TextDecoder().decode(bytes);
+    try {
+        // Decoding strictly rejects hex that is not something this extension wrote, rather than
+        // turning it into replacement characters and pinning the window to a garbage instance.
+        return new TextDecoder("utf-8", {fatal: true}).decode(bytes);
+    } catch {
+        return undefined;
+    }
 }
 
-// The url is kept exactly as configured, not normalized, so credentials scoped per url still match.
+// The url and the tenant are separate hex runs, so neither has to avoid a separator character. The
+// url is kept exactly as configured, not normalized, so credentials scoped per url still match.
 export function encodeInstanceAuthority(instance: KestraInstance): string {
-    return toHex(`${instance.url}|${instance.tenant}`);
+    return `${toHex(instance.url)}-${toHex(instance.tenant)}`;
 }
 
 // Undefined for anything this extension did not write, so older kestra:///namespace folders and the
 // ones the Kestra UI opens in the browser keep reading the instance from settings.
 export function decodeInstanceAuthority(authority: string): KestraInstance | undefined {
-    const decoded = authority ? fromHex(authority) : undefined;
-    if (decoded === undefined) {
+    const parts = authority.split("-");
+    if (parts.length !== 2) {
         return undefined;
     }
-    const separator = decoded.indexOf("|");
-    if (separator === -1) {
-        return undefined;
-    }
-    const url = decoded.slice(0, separator);
-    return url ? {url, tenant: decoded.slice(separator + 1)} : undefined;
+    const url = fromHex(parts[0]);
+    const tenant = fromHex(parts[1]);
+    return url && tenant !== undefined ? {url, tenant} : undefined;
 }

--- a/src/web/kestraFsProvider.ts
+++ b/src/web/kestraFsProvider.ts
@@ -43,10 +43,17 @@ export class KestraFS implements vscode.FileSystemProvider {
 
 	namespace: string;
 	apiClient: ApiClient;
+	private readonly authority: string;
 
-	constructor(namespace: string, apiClient: ApiClient) {
+	constructor(namespace: string, apiClient: ApiClient, authority: string = "") {
 		this.namespace = namespace;
 		this.apiClient = apiClient;
+		this.authority = authority;
+	}
+
+	// Child URIs keep the opened folder's authority, which is what pins the window to its instance.
+	public uriFor(path: string): vscode.Uri {
+		return vscode.Uri.from({scheme: "kestra", authority: this.authority, path});
 	}
 
 
@@ -237,7 +244,7 @@ export class KestraFS implements vscode.FileSystemProvider {
 	// Open a landing doc if the namespace ships one, but never fail activation when none exists.
 	async start() {
 		for (const doc of ["README.md", "getting-started.md"]) {
-			const uri = vscode.Uri.parse(`kestra:///${this.namespace}/${doc}`);
+			const uri = this.uriFor(`/${this.namespace}/${doc}`);
 			try {
 				await this.stat(uri);
 			} catch {
@@ -300,11 +307,11 @@ export class KestraFileSearchProvider implements FileSearchProvider {
 					reject(response.text());
 				}
 
-				resolve((await response.json() as Array<string>).map(path => vscode.Uri.parse("kestra:///" + this.namespace + path)));
+				resolve((await response.json() as Array<string>).map(path => this.fileSystemProvider.uriFor(`/${this.namespace}${path}`)));
 			}) as Promise<Uri[]>,
-			this.fileSystemProvider.readDirectory(vscode.Uri.parse("kestra:///" + this.namespace + "/" + this.fileSystemProvider.FLOWS_DIRECTORY))
+			this.fileSystemProvider.readDirectory(this.fileSystemProvider.uriFor(`/${this.namespace}/${this.fileSystemProvider.FLOWS_DIRECTORY}`))
 				.then(flows => flows
-					.map(([fileName]) => vscode.Uri.parse(`kestra:///${this.namespace}/${this.fileSystemProvider.FLOWS_DIRECTORY}/${fileName}`))
+					.map(([fileName]) => this.fileSystemProvider.uriFor(`/${this.namespace}/${this.fileSystemProvider.FLOWS_DIRECTORY}/${fileName}`))
 				)
 		]).then(([files, flows]) => {
 			return [...files, ...flows];

--- a/src/web/kestraFsProvider.ts
+++ b/src/web/kestraFsProvider.ts
@@ -15,6 +15,7 @@ import {
 	Uri
 } from 'vscode';
 import ApiClient from "./apiClient";
+import { kestraScheme } from "./constants";
 
 type KestraFileAttributes = {
 	fileName: string;
@@ -54,7 +55,7 @@ export class KestraFS implements vscode.FileSystemProvider {
 	// Builds a URI for a namespace-relative path. Child URIs keep the opened folder's authority,
 	// which is what pins the window to its instance.
 	public uriFor(relativePath: string): vscode.Uri {
-		return vscode.Uri.from({scheme: "kestra", authority: this.authority, path: `/${this.namespace}${relativePath}`});
+		return vscode.Uri.from({scheme: kestraScheme, authority: this.authority, path: `/${this.namespace}${relativePath}`});
 	}
 
 

--- a/src/web/kestraFsProvider.ts
+++ b/src/web/kestraFsProvider.ts
@@ -16,6 +16,7 @@ import {
 } from 'vscode';
 import ApiClient from "./apiClient";
 import { kestraScheme } from "./constants";
+import { logWarn } from "./log";
 
 type KestraFileAttributes = {
 	fileName: string;
@@ -291,33 +292,35 @@ tasks:
 }
 
 export class KestraFileSearchProvider implements FileSearchProvider {
-	namespace: string;
 	fileSystemProvider: KestraFS;
-	apiClient: ApiClient;
 
-	constructor(namespace: string, fileSystemProvider: KestraFS, apiClient: ApiClient) {
-		this.namespace = namespace;
+	constructor(fileSystemProvider: KestraFS) {
 		this.fileSystemProvider = fileSystemProvider;
-		this.apiClient = apiClient;
 	}
 
-	provideFileSearchResults(query: FileSearchQuery, options: FileSearchOptions, token: CancellationToken): ProviderResult<Uri[]> {
-		return Promise.all([
-			new Promise(async (resolve, reject) => {
-				const response = await this.apiClient.fileApi(this.namespace, `/search?q=${query.pattern}`);
-				if (!response.ok) {
-					reject(new Error(await response.text()));
-					return;
-				}
+	private async searchFiles(pattern: string): Promise<Uri[]> {
+		const fs = this.fileSystemProvider;
+		const response = await fs.apiClient.fileApi(fs.namespace, `/search?q=${encodeURIComponent(pattern)}`);
+		if (!response.ok) {
+			throw new Error(await response.text());
+		}
+		return (await response.json() as Array<string>).map(path => fs.uriFor(path));
+	}
 
-				resolve((await response.json() as Array<string>).map(path => this.fileSystemProvider.uriFor(path)));
-			}) as Promise<Uri[]>,
-			this.fileSystemProvider.readDirectory(this.fileSystemProvider.uriFor(`/${this.fileSystemProvider.FLOWS_DIRECTORY}`))
-				.then(flows => flows
-					.map(([fileName]) => this.fileSystemProvider.uriFor(`/${this.fileSystemProvider.FLOWS_DIRECTORY}/${fileName}`))
-				)
-		]).then(([files, flows]) => {
-			return [...files, ...flows];
-		});
+	private async searchFlows(): Promise<Uri[]> {
+		const flowsDirectory = `/${this.fileSystemProvider.FLOWS_DIRECTORY}`;
+		const flows = await this.fileSystemProvider.readDirectory(this.fileSystemProvider.uriFor(flowsDirectory));
+		return flows.map(([fileName]) => this.fileSystemProvider.uriFor(`${flowsDirectory}/${fileName}`));
+	}
+
+	// Half the results beat none, so one side failing does not discard the other.
+	async provideFileSearchResults(query: FileSearchQuery, options: FileSearchOptions, token: CancellationToken): Promise<Uri[]> {
+		const results = await Promise.allSettled([this.searchFiles(query.pattern), this.searchFlows()]);
+		for (const result of results) {
+			if (result.status === "rejected") {
+				logWarn(`Namespace search partly failed: ${result.reason}`);
+			}
+		}
+		return results.flatMap(result => result.status === "fulfilled" ? result.value : []);
 	}
 }

--- a/src/web/kestraFsProvider.ts
+++ b/src/web/kestraFsProvider.ts
@@ -53,8 +53,7 @@ export class KestraFS implements vscode.FileSystemProvider {
 		this.authority = authority;
 	}
 
-	// Builds a URI for a namespace-relative path. Child URIs keep the opened folder's authority,
-	// which is what pins the window to its instance.
+	// Keeps the folder's authority, which pins the window to its instance.
 	public uriFor(relativePath: string): vscode.Uri {
 		return vscode.Uri.from({scheme: kestraScheme, authority: this.authority, path: `/${this.namespace}${relativePath}`});
 	}

--- a/src/web/kestraFsProvider.ts
+++ b/src/web/kestraFsProvider.ts
@@ -51,9 +51,10 @@ export class KestraFS implements vscode.FileSystemProvider {
 		this.authority = authority;
 	}
 
-	// Child URIs keep the opened folder's authority, which is what pins the window to its instance.
-	public uriFor(path: string): vscode.Uri {
-		return vscode.Uri.from({scheme: "kestra", authority: this.authority, path});
+	// Builds a URI for a namespace-relative path. Child URIs keep the opened folder's authority,
+	// which is what pins the window to its instance.
+	public uriFor(relativePath: string): vscode.Uri {
+		return vscode.Uri.from({scheme: "kestra", authority: this.authority, path: `/${this.namespace}${relativePath}`});
 	}
 
 
@@ -244,7 +245,7 @@ export class KestraFS implements vscode.FileSystemProvider {
 	// Open a landing doc if the namespace ships one, but never fail activation when none exists.
 	async start() {
 		for (const doc of ["README.md", "getting-started.md"]) {
-			const uri = this.uriFor(`/${this.namespace}/${doc}`);
+			const uri = this.uriFor(`/${doc}`);
 			try {
 				await this.stat(uri);
 			} catch {
@@ -304,14 +305,15 @@ export class KestraFileSearchProvider implements FileSearchProvider {
 			new Promise(async (resolve, reject) => {
 				const response = await this.apiClient.fileApi(this.namespace, `/search?q=${query.pattern}`);
 				if (!response.ok) {
-					reject(response.text());
+					reject(new Error(await response.text()));
+					return;
 				}
 
-				resolve((await response.json() as Array<string>).map(path => this.fileSystemProvider.uriFor(`/${this.namespace}${path}`)));
+				resolve((await response.json() as Array<string>).map(path => this.fileSystemProvider.uriFor(path)));
 			}) as Promise<Uri[]>,
-			this.fileSystemProvider.readDirectory(this.fileSystemProvider.uriFor(`/${this.namespace}/${this.fileSystemProvider.FLOWS_DIRECTORY}`))
+			this.fileSystemProvider.readDirectory(this.fileSystemProvider.uriFor(`/${this.fileSystemProvider.FLOWS_DIRECTORY}`))
 				.then(flows => flows
-					.map(([fileName]) => this.fileSystemProvider.uriFor(`/${this.namespace}/${this.fileSystemProvider.FLOWS_DIRECTORY}/${fileName}`))
+					.map(([fileName]) => this.fileSystemProvider.uriFor(`/${this.fileSystemProvider.FLOWS_DIRECTORY}/${fileName}`))
 				)
 		]).then(([files, flows]) => {
 			return [...files, ...flows];

--- a/src/web/log.ts
+++ b/src/web/log.ts
@@ -11,6 +11,10 @@ export function initLog(context: vscode.ExtensionContext): void {
     }
 }
 
+export function logInfo(message: string): void {
+    channel?.info(message);
+}
+
 export function logWarn(message: string): void {
     channel?.warn(message);
 }

--- a/src/web/namespaceFiles.ts
+++ b/src/web/namespaceFiles.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import ApiClient from './apiClient';
 import {SyncOutcome, basename, namespacePath, isIgnored, reachabilityError, uploadNotice} from './namespaceFilesHelpers';
 import {logWarn} from './log';
+import {kestraScheme} from './constants';
 
 type LocalFile = {uri: vscode.Uri; relative: string};
 
@@ -277,7 +278,7 @@ export async function uploadFileToNamespace(apiClient: ApiClient, resource?: vsc
         showNotice('error', "Open or select a file to upload.");
         return;
     }
-    if (uris.some(uri => uri.scheme === 'kestra')) {
+    if (uris.some(uri => uri.scheme === kestraScheme)) {
         showNotice('error', "That file already lives on a Kestra namespace.");
         return;
     }
@@ -315,7 +316,7 @@ export async function syncFolderToNamespace(apiClient: ApiClient, resource?: vsc
     if (uris.length === 0) {
         return;
     }
-    if (uris.some(uri => uri.scheme === 'kestra')) {
+    if (uris.some(uri => uri.scheme === kestraScheme)) {
         showNotice('error', "That folder already lives on a Kestra namespace.");
         return;
     }


### PR DESCRIPTION
- closes #49 